### PR TITLE
Fix Process.Start with URL for .NET 5

### DIFF
--- a/FloatingGlucose/FloatingGlucose.cs
+++ b/FloatingGlucose/FloatingGlucose.cs
@@ -761,7 +761,8 @@ namespace FloatingGlucose
             {
                 try
                 {
-                    Process.Start(url);
+                    var processStartInfo = new ProcessStartInfo(url) {UseShellExecute = true};
+                    Process.Start(processStartInfo);
                 }
                 catch (Win32Exception ex)
                 {


### PR DESCRIPTION
The option to open the nightscout site from the menu of the application is broken, and throws a Win32Exception.

This PR addresses the issue by specifying the changed default (UseShellExecute was true in .NET Framework, and is now false in .NET)